### PR TITLE
Add a basic REPL

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+    - name: Run cargo fmt
+      run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,7 +97,7 @@ checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -182,6 +188,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "regex",
+ "termion",
 ]
 
 [[package]]
@@ -189,6 +196,17 @@ name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+
+[[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -201,6 +219,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "once_cell"
@@ -227,6 +251,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,7 +288,7 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -272,6 +311,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termion"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
+dependencies = [
+ "libc",
+ "libredox",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 regex = "*"
 clap = { version = "4.0", features = ["derive"] }
+termion = "3.0.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,4 +16,3 @@ impl Display for SyntaxError {
 
 #[derive(Debug)]
 pub struct TypeError(pub String);
-

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -89,6 +89,6 @@ impl Lexer {
                 None => continue,
             }
         }
-        return None;
+        None
     }
 }

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -37,10 +37,10 @@ pub struct Token {
 impl Token {
     pub fn get_prec(&self) -> i32 {
         match self.kind {
-            Kind::Mul | Kind::Div => return 3,
-            Kind::Plus | Kind::Min => return 2,
-            Kind::DoubleEq | Kind::Geq | Kind::Neq | Kind::Leq => return 1,
-            _ => return 0,
+            Kind::Mul | Kind::Div => 3,
+            Kind::Plus | Kind::Min => 2,
+            Kind::DoubleEq | Kind::Geq | Kind::Neq | Kind::Leq => 1,
+            _ => 0,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn build(path: &String, cli: &Cli) {
     if path.ends_with(".kr") {
         let program = match fs::read_to_string(path) {
             Ok(value) => value,
-            Err(e) => panic!("{}", e),
+            Err(e) => panic!("{e}"),
         };
         let ast = match KarmParser::new(program).program() {
             Ok(ast) => ast,
@@ -65,6 +65,6 @@ fn build(path: &String, cli: &Cli) {
 }
 
 fn _shell() {
-    let session = repl::Repl::new(">>>".to_string(), "...".to_string(), Vec::new());
+    let session = repl::Repl::new(">>> ".to_string(), "... ".to_string(), Vec::new());
     session.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,13 @@ fn build(path: &String, cli: &Cli) {
             Ok(value) => value,
             Err(e) => panic!("{}", e),
         };
-        let ast = KarmParser::new(program).program();
+        let ast = match KarmParser::new(program).program() {
+            Ok(ast) => ast,
+            Err(err) => {
+                println!("{err}");
+                exit(1)
+            }
+        };
         if cli.ast == true {
             println!("{:#?}", ast);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod errors;
 mod lexer;
 mod parser;
+mod repl;
 // mod typechecker;
 
 use clap::{Parser, Subcommand};

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
 
     match &cli.command {
         Some(Commands::Build { file }) => build(file, &cli),
-        Some(Commands::Shell {}) => {}
+        Some(Commands::Shell {}) => _shell(),
         None => {}
     }
 }
@@ -58,4 +58,7 @@ fn build(path: &String, cli: &Cli) {
     }
 }
 
-fn _shell() {}
+fn _shell() {
+    let session = repl::Repl::new(">>>".to_string(), "...".to_string(), Vec::new());
+    session.run();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn build(path: &String, cli: &Cli) {
                 exit(1)
             }
         };
-        if cli.ast == true {
+        if cli.ast {
             println!("{:#?}", ast);
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ use crate::lexer::tokens::{Kind, Token};
 use crate::lexer::Lexer;
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Expr { 
+pub enum Expr {
     Literal(Literal),
     LamCall {
         ident: String,
@@ -120,7 +120,7 @@ impl Parser {
     // ? No more function nesting (we call if_exprs and not expr everywhere)
     fn lam_expr(&mut self) -> Result<Expr, SyntaxError> {
         self.eat(&mut Kind::Lam)?;
-        let id = self.eat(&Kind::Ident)?.value; 
+        let id = self.eat(&Kind::Ident)?.value;
         let mut style = LamStyle::Prefix;
         if self.next_token().kind == Kind::Bar {
             self.eat(&Kind::Bar)?;
@@ -203,7 +203,7 @@ impl Parser {
             left = Expr::LamCall {
                 ident: op,
                 style: LamStyle::Infix,
-                params: Some(vec![left, right])
+                params: Some(vec![left, right]),
             };
         }
         Ok(left)
@@ -221,7 +221,7 @@ impl Parser {
             left = Expr::LamCall {
                 ident: op,
                 style: LamStyle::Infix,
-                params: Some(vec![left, right])
+                params: Some(vec![left, right]),
             };
         }
         Ok(left)
@@ -236,7 +236,7 @@ impl Parser {
             left = Expr::LamCall {
                 ident: op,
                 style: LamStyle::Infix,
-                params: Some(vec![left, right])
+                params: Some(vec![left, right]),
             };
         }
         Ok(left)
@@ -345,34 +345,41 @@ mod tests {
                     cond: Box::from(Expr::LamCall {
                         ident: "<=".to_owned(),
                         style: LamStyle::Infix,
-                        params: Some(vec![Expr::Var("n".to_owned()), Expr::Literal(Literal::Int(1))])
+                        params: Some(vec![
+                            Expr::Var("n".to_owned()),
+                            Expr::Literal(Literal::Int(1))
+                        ])
                     }),
                     then: Box::from(Expr::Var("n".to_owned())),
                     alter: Box::from(Expr::LamCall {
                         ident: "+".to_owned(),
                         style: LamStyle::Infix,
-                        params: Some(
-                            vec![
-                                Expr::LamCall {
-                                    ident: "fib".to_owned(),
-                                    style: LamStyle::Prefix,
-                                    params: Some(vec![Expr::LamCall {
-                                        ident: "-".to_owned(),
-                                        style: LamStyle::Infix,
-                                        params: Some(vec![Expr::Var("n".to_owned()), Expr::Literal(Literal::Int(1))])
-                                    }])
-                                },
-                                Expr::LamCall {
-                                    ident: "fib".to_owned(),
-                                    style: LamStyle::Prefix,
-                                    params: Some(vec![Expr::LamCall {
-                                        ident: "-".to_owned(), 
-                                        style: LamStyle::Infix,
-                                        params: Some(vec![Expr::Var("n".to_owned()), Expr::Literal(Literal::Int(2))])
-                                    }])
-                                }
-                            ]
-                        ),
+                        params: Some(vec![
+                            Expr::LamCall {
+                                ident: "fib".to_owned(),
+                                style: LamStyle::Prefix,
+                                params: Some(vec![Expr::LamCall {
+                                    ident: "-".to_owned(),
+                                    style: LamStyle::Infix,
+                                    params: Some(vec![
+                                        Expr::Var("n".to_owned()),
+                                        Expr::Literal(Literal::Int(1))
+                                    ])
+                                }])
+                            },
+                            Expr::LamCall {
+                                ident: "fib".to_owned(),
+                                style: LamStyle::Prefix,
+                                params: Some(vec![Expr::LamCall {
+                                    ident: "-".to_owned(),
+                                    style: LamStyle::Infix,
+                                    params: Some(vec![
+                                        Expr::Var("n".to_owned()),
+                                        Expr::Literal(Literal::Int(2))
+                                    ])
+                                }])
+                            }
+                        ]),
                     })
                 })
             }])

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn fib_func() {
         assert_eq!(
-            Parser::new(r#"fn fib :: n -> if n <= 1 ? n : fib(n - 1) + fib(n - 2);"#.to_owned())
+            Parser::new(r#"lam fib :: n -> if n <= 1 ? n : fib(n - 1) + fib(n - 2);"#.to_owned())
                 .program()
                 .unwrap(),
             Program(vec![Expr::LamDef {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,7 +57,7 @@ impl Parser {
         }
     }
 
-    pub fn program(mut self) -> Program {
+    pub fn program(mut self) -> Result<Program, SyntaxError> {
         if self.next.is_none() {
             println!("Program Terminated : Lookahead is empty, nothing to parse.");
             exit(1)
@@ -65,19 +65,13 @@ impl Parser {
         self.parse()
     }
 
-    pub fn parse(&mut self) -> Program {
+    pub fn parse(&mut self) -> Result<Program, SyntaxError> {
         let mut ast: Vec<Expr> = Vec::new();
         while !self.next.is_none() {
             let exp = self.expr_def();
-            ast.push(match exp {
-                Ok(val) => val,
-                Err(e) => {
-                    println!("{}", e);
-                    exit(1)
-                }
-            });
+            ast.push(exp?);
         }
-        Program(ast)
+        Ok(Program(ast))
     }
 
     fn expr_def(&mut self) -> Result<Expr, SyntaxError> {
@@ -336,7 +330,8 @@ mod tests {
     fn fib_func() {
         assert_eq!(
             Parser::new(r#"fn fib :: n -> if n <= 1 ? n : fib(n - 1) + fib(n - 2);"#.to_owned())
-                .program(),
+                .program()
+                .unwrap(),
             Program(vec![Expr::LamDef {
                 ident: "fib".to_owned(),
                 style: LamStyle::Prefix,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,6 +31,16 @@ pub struct Repl {
     was_newline: bool,
 }
 
+fn newline(stdout: &mut Stdout) {
+    let height = termion::terminal_size().unwrap().1;
+    let cursor_y = stdout.cursor_pos().unwrap().1;
+    if cursor_y >= height {
+        write!(stdout, "{}", termion::scroll::Up(1)).unwrap();
+    }
+    let cursor_y = stdout.cursor_pos().unwrap().1;
+    write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+}
+
 impl Repl {
     pub fn new(prompt1: String, prompt2: String, history: Vec<String>) -> Self {
         Repl {
@@ -75,20 +85,17 @@ impl Repl {
     }
     fn show(&self, stdout: &mut Stdout) {
         if self.was_newline {
-            let cursor_y = stdout.cursor_pos().unwrap().1;
-            write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+            newline(stdout);
         }
         if let Some(result) = &self.command_result {
             for c in result.chars() {
                 if c == '\n' {
-                    let cursor_y = stdout.cursor_pos().unwrap().1;
-                    write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+                    newline(stdout);
                 } else {
                     write!(stdout, "{c}").unwrap();
                 }
             }
-            let cursor_y = stdout.cursor_pos().unwrap().1;
-            write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+            newline(stdout);
         }
         let cursor_y = stdout.cursor_pos().unwrap().1;
         write!(

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,11 +1,18 @@
+use std::io::{stdin, stdout, Stdout, Write};
+use termion::cursor::DetectCursorPos;
+use termion::event::Key;
+use termion::input::TermRead;
+use termion::raw::IntoRawMode;
 /// The structure representing the REPL's state
-struct Repl {
+pub struct Repl {
     /// The string printed before, the first line of the command.
     /// **This string must not contain newlines.**
     prompt1: String,
     /// The string printed before, the following lines of the command.
     /// **This string must not contain newlines.**
     prompt2: String,
+    /// The command currently being typed
+    current_line: String,
     /// The list of all previously typed lines.
     /// **This vector must not contain empty strings.**
     history: Vec<String>,
@@ -15,4 +22,97 @@ struct Repl {
     /// The index of the current line as found in *history*, if the line is not
     /// yet in history, this should be equal to *history.len()*.
     hist_idx: usize,
+    /// The index of the cursor in *current_line*
+    cursor_idx: usize,
+    /// The value will be *Some(x)*, where x is the result of the previous command,
+    /// **if the last line was the end of a command**
+    command_result: Option<String>,
+    /// true if the last event resulted in a newline
+    was_newline: bool,
+}
+
+impl Repl {
+    pub fn new(prompt1: String, prompt2: String, history: Vec<String>) -> Self {
+        Repl {
+            current_line: String::new(),
+            first_command_line: history.len(),
+            hist_idx: history.len(),
+            cursor_idx: 0,
+            command_result: None,
+            was_newline: false,
+            prompt1,
+            prompt2,
+            history,
+        }
+    }
+    fn update(&mut self, c: Key) {
+        self.command_result = None;
+        self.was_newline = false;
+        match c {
+            Key::Char(c) => {
+                if c == '\n' {
+                    if !self.current_line.is_empty() {
+                        self.was_newline = true;
+                        self.hist_idx += 1;
+                        self.cursor_idx = 0;
+                        self.history.push(self.current_line.clone());
+                        // The current line ends a command
+                        if self.current_line.ends_with(";") {
+                            let full_command =
+                                self.history[self.first_command_line..self.hist_idx].join("\n");
+                            self.command_result = Some(format!("TODO: execute {full_command}"));
+                            self.first_command_line = self.hist_idx;
+                        }
+                        self.current_line.clear()
+                    }
+                } else {
+                    self.current_line.insert(self.cursor_idx, c);
+                    self.cursor_idx += 1;
+                }
+            }
+            _ => todo!(),
+        }
+    }
+    fn show(&self, stdout: &mut Stdout) {
+        if self.was_newline {
+            let cursor_y = stdout.cursor_pos().unwrap().1;
+            write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+        }
+        if let Some(result) = &self.command_result {
+            for c in result.chars() {
+                if c == '\n' {
+                    let cursor_y = stdout.cursor_pos().unwrap().1;
+                    write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+                } else {
+                    write!(stdout, "{c}").unwrap();
+                }
+            }
+            let cursor_y = stdout.cursor_pos().unwrap().1;
+            write!(stdout, "{}", termion::cursor::Goto(1, cursor_y + 1)).unwrap();
+        }
+        let cursor_y = stdout.cursor_pos().unwrap().1;
+        write!(
+            stdout,
+            "{}{}",
+            termion::clear::CurrentLine,
+            termion::cursor::Goto(1, cursor_y)
+        )
+        .unwrap();
+        if self.hist_idx == self.first_command_line {
+            write!(stdout, "{}", self.prompt1).unwrap();
+        } else {
+            write!(stdout, "{}", self.prompt2).unwrap();
+        }
+        write!(stdout, "{}", self.current_line).unwrap();
+        stdout.flush().unwrap();
+    }
+    pub fn run(mut self) {
+        let stdin = stdin();
+        let mut stdout = stdout().into_raw_mode().unwrap();
+        self.show(&mut stdout);
+        for c in stdin.keys() {
+            self.update(c.unwrap());
+            self.show(&mut stdout);
+        }
+    }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,3 +1,4 @@
+use crate::parser;
 use std::io::{stdin, stdout, Stdout, Write};
 use termion::cursor::DetectCursorPos;
 use termion::event::Key;
@@ -77,7 +78,10 @@ impl Repl {
                         // The current line ends a command
                         if self.current_line.ends_with(";") {
                             let full_command = self.history[self.first_command_line..].join("\n");
-                            self.command_result = Some(Ok(format!("TODO: execute {full_command}")));
+                            self.command_result = Some(Ok(format!(
+                                "{:#?}",
+                                parser::Parser::new(full_command).parse()
+                            )));
                             self.first_command_line = self.hist_idx;
                             self.tbc = false;
                         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,18 @@
+/// The structure representing the REPL's state
+struct Repl {
+    /// The string printed before, the first line of the command.
+    /// **This string must not contain newlines.**
+    prompt1: String,
+    /// The string printed before, the following lines of the command.
+    /// **This string must not contain newlines.**
+    prompt2: String,
+    /// The list of all previously typed lines.
+    /// **This vector must not contain empty strings.**
+    history: Vec<String>,
+    /// The index in history of the first line of the command, if the current
+    /// command has no lines in history, this should be equal to *history.len()*.
+    first_command_line: usize,
+    /// The index of the current line as found in *history*, if the line is not
+    /// yet in history, this should be equal to *history.len()*.
+    hist_idx: usize,
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -86,6 +86,14 @@ impl Repl {
                     self.current_line.remove(self.cursor_idx);
                 }
             }
+            Key::Left => {
+                self.cursor_idx = self.cursor_idx.checked_sub(1).unwrap_or(self.cursor_idx)
+            }
+            Key::Right => {
+                if self.cursor_idx < self.current_line.len() {
+                    self.cursor_idx += 1;
+                }
+            }
             _ => todo!(),
         }
     }
@@ -111,12 +119,18 @@ impl Repl {
             termion::cursor::Goto(1, cursor_y)
         )
         .unwrap();
-        if self.hist_idx == self.first_command_line {
-            write!(stdout, "{}", self.prompt1).unwrap();
+        let prompt = if self.hist_idx == self.first_command_line {
+            &self.prompt1
         } else {
-            write!(stdout, "{}", self.prompt2).unwrap();
-        }
-        write!(stdout, "{}", self.current_line).unwrap();
+            &self.prompt2
+        };
+        write!(
+            stdout,
+            "{prompt}{}{}",
+            self.current_line,
+            termion::cursor::Goto((prompt.len() + self.cursor_idx + 1) as u16, cursor_y)
+        )
+        .unwrap();
         stdout.flush().unwrap();
     }
     pub fn run(mut self) {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -32,6 +32,8 @@ pub struct Repl {
     /// true if the previous line has been entered without a ';' at the end of it,
     /// false otherwise
     tbc: bool,
+    /// false if the repl should exit, true otherwise
+    running: bool,
 }
 
 fn newline(stdout: &mut Stdout) {
@@ -54,6 +56,7 @@ impl Repl {
             command_result: None,
             was_newline: false,
             tbc: false,
+            running: true,
             prompt1,
             prompt2,
             history,
@@ -111,7 +114,8 @@ impl Repl {
                     self.current_line = self.history[self.hist_idx].clone();
                 }
             }
-            _ => todo!(),
+            Key::Ctrl('c') | Key::Ctrl('d') => self.running = false,
+            _ => (),
         }
     }
     fn show(&self, stdout: &mut Stdout) {
@@ -156,6 +160,9 @@ impl Repl {
         self.show(&mut stdout);
         for c in stdin.keys() {
             self.update(c.unwrap());
+            if !self.running {
+                break;
+            }
             self.show(&mut stdout);
         }
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -76,7 +76,7 @@ impl Repl {
                         self.hist_idx = self.history.len();
                         self.tbc = true;
                         // The current line ends a command
-                        if self.current_line.ends_with(";") {
+                        if self.current_line.ends_with(';') {
                             let full_command = self.history[self.first_command_line..].join("\n");
                             let ast = parser::Parser::new(full_command)
                                 .parse()

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -78,10 +78,11 @@ impl Repl {
                         // The current line ends a command
                         if self.current_line.ends_with(";") {
                             let full_command = self.history[self.first_command_line..].join("\n");
-                            self.command_result = Some(Ok(format!(
-                                "{:#?}",
-                                parser::Parser::new(full_command).parse()
-                            )));
+                            let ast = parser::Parser::new(full_command)
+                                .parse()
+                                .map(|x| format!("{:#?}", x))
+                                .map_err(|err| format!("{err}"));
+                            self.command_result = Some(ast);
                             self.first_command_line = self.hist_idx;
                             self.tbc = false;
                         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -26,7 +26,7 @@ pub struct Repl {
     cursor_idx: usize,
     /// The value will be *Some(x)*, where x is the result of the previous command,
     /// **if the last line was the end of a command**
-    command_result: Option<String>,
+    command_result: Option<Result<String, String>>,
     /// true if the last event resulted in a newline
     was_newline: bool,
     /// true if the previous line has been entered without a ';' at the end of it,
@@ -77,7 +77,7 @@ impl Repl {
                         // The current line ends a command
                         if self.current_line.ends_with(";") {
                             let full_command = self.history[self.first_command_line..].join("\n");
-                            self.command_result = Some(format!("TODO: execute {full_command}"));
+                            self.command_result = Some(Ok(format!("TODO: execute {full_command}")));
                             self.first_command_line = self.hist_idx;
                             self.tbc = false;
                         }
@@ -123,6 +123,10 @@ impl Repl {
             newline(stdout);
         }
         if let Some(result) = &self.command_result {
+            let result = result
+                .as_ref()
+                .map(|x| x.clone())
+                .unwrap_or_else(|x| format!("Error: {x}"));
             for c in result.chars() {
                 if c == '\n' {
                     newline(stdout);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -80,6 +80,12 @@ impl Repl {
                     self.cursor_idx += 1;
                 }
             }
+            Key::Backspace => {
+                if self.cursor_idx != 0 {
+                    self.cursor_idx -= 1;
+                    self.current_line.remove(self.cursor_idx);
+                }
+            }
             _ => todo!(),
         }
     }


### PR DESCRIPTION
# Basic description
This PR adds a small REPL similar to the one found in python. It is uses the [termion](https://docs.rs/termion/latest/termion/) library. It is based on a simplified version of the [Elm architecture](https://guide.elm-lang.org/architecture/) (it is basically the same method, except we do not send any events from the update function). This makes the REPL flexible across TUI libraries, (the logic is strictly in the update function, if we were to change the TUI library, we would only have to change the *show* and the *run* functions).
# Some problems
- It is not portable across Operating systems: most notably it does not work on Windows (unless WSL is used), this is due to the fact the termion does not work on windows.
- There is a lot of copying going on: for example, the command string is copied every time a newline is added, this can be fixed if instead of having a separate field for the command string, we use the last history entry as the current command, but to me this sounds like a hack.
- I would like it better if the *view* method is completely independent from termion, this however is hard to do in raw mode.
# Changes to the parser
- Handle errors gracefully.
# Todos
- ~Add the ability to navigate the history~
- ~Add the ability to go left and right~
- ~handle backspaces~
- ~actually execute the commands.~ (partially done, since there is no way to execute programs at the moment).