### PR TITLE
Make the lexer take &str instead of a String

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -57,7 +57,7 @@ impl<'a> Lexer<'a> {
         self.cursor < self.program.len()
     }
 
-    fn match_token(&mut self, tok_kind: Option<Kind>, capture: &str) -> Option<Token> {
+    fn match_token(&mut self, tok_kind: Option<Kind>, capture: &'a str) -> Option<Token<'a>> {
         self.cursor += capture.len();
         self.col_cursor += capture.len() - 1;
         match tok_kind {
@@ -68,7 +68,7 @@ impl<'a> Lexer<'a> {
             }
             Some(kind) => Some(Token {
                 kind,
-                value: capture.to_string(),
+                value: capture,
             }),
             None => self.next(),
         }
@@ -76,7 +76,7 @@ impl<'a> Lexer<'a> {
 }
 
 impl<'a> Iterator for Lexer<'a> {
-    type Item = Token;
+    type Item = Token<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.has_more_token() {

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -29,12 +29,12 @@ pub enum Kind {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Token {
+pub struct Token<'a> {
     pub kind: Kind,
-    pub value: String,
+    pub value: &'a str,
 }
 
-impl Token {
+impl<'a> Token<'a> {
     pub fn get_prec(&self) -> i32 {
         match self.kind {
             Kind::Mul | Kind::Div => 3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn build(path: &String, cli: &Cli) {
             Ok(value) => value,
             Err(e) => panic!("{e}"),
         };
-        let ast = match KarmParser::new(program).program() {
+        let ast = match KarmParser::new(&program).program() {
             Ok(ast) => ast,
             Err(err) => {
                 println!("{err}");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,19 +40,19 @@ pub enum Literal {
     Int(i32),
 }
 
-// TODO: Simple disclaimers : 
+// TODO: Simple disclaimers :
 // ! Could the parser potentially become an iterator too ?
 // ! Should I use a more functional approach for the parser ?
 #[derive(PartialEq)]
 pub struct Program(pub Vec<Expr>);
 
-pub struct Parser {
+pub struct Parser<'a> {
     next: Option<Token>,
-    lexer: Lexer,
+    lexer: Lexer<'a>,
 }
 
-impl Parser {
-    pub fn new(program: String) -> Self {
+impl<'a> Parser<'a> {
+    pub fn new(program: &'a str) -> Self {
         let mut lexer = Lexer::new(program);
         Self {
             next: lexer.next(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -330,7 +330,7 @@ mod tests {
     #[test]
     fn fib_func() {
         assert_eq!(
-            Parser::new(r#"lam fib :: n -> if n <= 1 ? n : fib(n - 1) + fib(n - 2);"#.to_owned())
+            Parser::new(r#"lam fib :: n -> if n <= 1 ? n : fib(n - 1) + fib(n - 2);"#)
                 .program()
                 .unwrap(),
             Program(vec![Expr::LamDef {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,7 +47,7 @@ pub enum Literal {
 pub struct Program(pub Vec<Expr>);
 
 pub struct Parser<'a> {
-    next: Option<Token>,
+    next: Option<Token<'a>>,
     lexer: Lexer<'a>,
 }
 
@@ -109,13 +109,13 @@ impl<'a> Parser<'a> {
     fn use_expr(&mut self) -> Result<Expr, SyntaxError> {
         self.eat(&Kind::Use)?;
         let path = self.eat(&Kind::String)?.value;
-        Ok(Expr::Use(path))
+        Ok(Expr::Use(path.to_string()))
     }
 
     // ? No more function nesting (we call if_exprs and not expr everywhere)
     fn lam_expr(&mut self) -> Result<Expr, SyntaxError> {
         self.eat(&Kind::Lam)?;
-        let id = self.eat(&Kind::Ident)?.value;
+        let id = self.eat(&Kind::Ident)?.value.to_string();
         let mut style = LamStyle::Prefix;
         if self.next_token().kind == Kind::Bar {
             self.eat(&Kind::Bar)?;
@@ -127,7 +127,7 @@ impl<'a> Parser<'a> {
             let mut params: Vec<String> = vec![];
             self.eat(&Kind::DoubleColon)?;
             while self.next_token().kind != Kind::Arrow {
-                params.push(self.eat(&Kind::Ident)?.value);
+                params.push(self.eat(&Kind::Ident)?.value.to_string());
                 if self.next_token().kind == Kind::Comma {
                     self.eat(&Kind::Comma)?;
                 }
@@ -135,7 +135,7 @@ impl<'a> Parser<'a> {
 
             self.eat(&Kind::Arrow)?;
             return Ok(Expr::LamDef {
-                ident: id,
+                ident: id.to_string(),
                 style,
                 params: Some(params),
                 operation: Box::new(self.if_expr()?),
@@ -146,7 +146,7 @@ impl<'a> Parser<'a> {
         self.eat(&Kind::Arrow)?;
 
         Ok(Expr::LamDef {
-            ident: id,
+            ident: id.to_string(),
             style,
             params: None,
             operation: Box::new(self.if_expr()?),
@@ -193,10 +193,10 @@ impl<'a> Parser<'a> {
     fn conditional_expr(&mut self) -> Result<Expr, SyntaxError> {
         let mut left: Expr = self.low_prec_expr()?;
         while self.next_token().get_prec() == 1 {
-            let op = self.eat(&self.next_token().clone().kind)?.value;
+            let op = self.eat(&self.next_token().clone().kind)?.value.to_string();
             let right = self.low_prec_expr()?;
             left = Expr::LamCall {
-                ident: op,
+                ident: op.to_string(),
                 style: LamStyle::Infix,
                 params: Some(vec![left, right]),
             };
@@ -209,12 +209,12 @@ impl<'a> Parser<'a> {
         let mut left = self.high_prec_expr()?;
         while self.next_token().get_prec() == 2 {
             let op = match self.eat(&self.next_token().clone().kind) {
-                Ok(val) => val.value,
+                Ok(val) => val.value.to_string(),
                 Err(e) => return Err(e),
             };
             let right = self.high_prec_expr()?;
             left = Expr::LamCall {
-                ident: op,
+                ident: op.to_string(),
                 style: LamStyle::Infix,
                 params: Some(vec![left, right]),
             };
@@ -226,10 +226,10 @@ impl<'a> Parser<'a> {
     fn high_prec_expr(&mut self) -> Result<Expr, SyntaxError> {
         let mut left: Expr = self.factor()?;
         while self.next_token().get_prec() == 3 {
-            let op = self.eat(&self.next_token().clone().kind)?.value;
+            let op = self.eat(&self.next_token().clone().kind)?.value.to_string();
             let right = self.factor()?;
             left = Expr::LamCall {
-                ident: op,
+                ident: op.to_string(),
                 style: LamStyle::Infix,
                 params: Some(vec![left, right]),
             };
@@ -245,7 +245,9 @@ impl<'a> Parser<'a> {
                     Err(e) => return Err(e),
                 },
             ))),
-            Kind::String => Ok(Expr::Literal(Literal::Str(self.eat(&Kind::String)?.value))),
+            Kind::String => Ok(Expr::Literal(Literal::Str(
+                self.eat(&Kind::String)?.value.to_string(),
+            ))),
             Kind::LParen => self.parenthesized_expr(),
             _ => self.ident(),
         };
@@ -253,7 +255,7 @@ impl<'a> Parser<'a> {
     }
 
     fn ident(&mut self) -> Result<Expr, SyntaxError> {
-        let id = self.eat(&Kind::Ident)?;
+        let id = self.eat(&Kind::Ident)?.value.to_string();
         if self.next_token().kind == Kind::LParen {
             let mut _params: Vec<Expr> = Vec::new();
             self.eat(&Kind::LParen)?;
@@ -268,12 +270,12 @@ impl<'a> Parser<'a> {
                 false => Some(_params),
             };
             return Ok(Expr::LamCall {
-                ident: id.value,
+                ident: id,
                 style: LamStyle::Prefix,
                 params,
             });
         }
-        Ok(Expr::Var(id.value))
+        Ok(Expr::Var(id))
     }
 
     fn next_token(&self) -> &Token {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -241,7 +241,7 @@ impl<'a> Parser<'a> {
         let literal: Result<Expr, SyntaxError> = match self.next_token().kind {
             Kind::Integer => Ok(Expr::Literal(Literal::Int(
                 match self.eat(&Kind::Integer) {
-                    Ok(val) => val.value.to_string().parse::<i32>().unwrap(),
+                    Ok(val) => val.value.parse::<i32>().unwrap(),
                     Err(e) => return Err(e),
                 },
             ))),

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -78,7 +78,7 @@ impl Repl {
                         // The current line ends a command
                         if self.current_line.ends_with(';') {
                             let full_command = self.history[self.first_command_line..].join("\n");
-                            let ast = parser::Parser::new(full_command)
+                            let ast = parser::Parser::new(&full_command)
                                 .parse()
                                 .map(|x| format!("{:#?}", x))
                                 .map_err(|err| format!("{err}"));


### PR DESCRIPTION
This PR removes the need to copy the program string when creating the lexer. This fixes the issue pointed to by the comment at `src/lexer.rs:90`. This is done by using a lifetime on the lexer. As far as I can see, this also removes the need to copy out of the program string for things such as if statements, parentheses  and numbers. 